### PR TITLE
Do on each

### DIFF
--- a/lib/Rx/Observable/BaseObservable.php
+++ b/lib/Rx/Observable/BaseObservable.php
@@ -524,14 +524,13 @@ abstract class BaseObservable implements ObservableInterface
      *  Invokes an action for each element in the observable sequence and invokes an action upon graceful or exceptional termination of the observable sequence.
      *  This method can be used for debugging, logging, etc. of query behavior by intercepting the message stream to run arbitrary actions for messages on the pipeline.
      *
-     * @param $observerOrOnNext
-     * @param null $onError
-     * @param null $onCompleted
+     * @param ObserverInterface $observer
+     *
      * @return \Rx\Observable\AnonymousObservable
      */
-    public function doOnEach($observerOrOnNext, $onError = null, $onCompleted = null)
+    public function doOnEach(ObserverInterface $observer)
     {
-        return $this->lift(new DoOnEachOperator($observerOrOnNext, $onError, $onCompleted));
+        return $this->lift(new DoOnEachOperator($observer));
     }
 
     /**

--- a/lib/Rx/Observable/BaseObservable.php
+++ b/lib/Rx/Observable/BaseObservable.php
@@ -12,13 +12,13 @@ use Rx\Operator\ConcatOperator;
 use Rx\Operator\CountOperator;
 use Rx\Operator\DeferOperator;
 use Rx\Operator\DistinctUntilChangedOperator;
+use Rx\Operator\DoOnEachOperator;
 use Rx\Operator\NeverOperator;
 use Rx\Operator\OperatorInterface;
 use Rx\Operator\ReduceOperator;
 use Rx\Operator\ScanOperator;
 use Rx\Operator\SkipLastOperator;
 use Rx\Operator\SkipUntilOperator;
-use Rx\Operator\TapOperator;
 use Rx\Operator\ToArrayOperator;
 use Rx\Scheduler\ImmediateScheduler;
 use Rx\Disposable\CompositeDisposable;
@@ -529,9 +529,9 @@ abstract class BaseObservable implements ObservableInterface
      * @param null $onCompleted
      * @return \Rx\Observable\AnonymousObservable
      */
-    public function tap($observerOrOnNext, $onError = null, $onCompleted = null)
+    public function doOnEach($observerOrOnNext, $onError = null, $onCompleted = null)
     {
-        return $this->lift(new TapOperator($observerOrOnNext, $onError, $onCompleted));
+        return $this->lift(new DoOnEachOperator($observerOrOnNext, $onError, $onCompleted));
     }
 
     /**

--- a/lib/Rx/Operator/DoOnEachOperator.php
+++ b/lib/Rx/Operator/DoOnEachOperator.php
@@ -1,15 +1,13 @@
 <?php
 
-
 namespace Rx\Operator;
-
 
 use Rx\ObservableInterface;
 use Rx\Observer\CallbackObserver;
 use Rx\ObserverInterface;
 use Rx\SchedulerInterface;
 
-class TapOperator implements OperatorInterface
+class DoOnEachOperator implements OperatorInterface
 {
 
     protected $observerOrOnNext;

--- a/test/Rx/Functional/Operator/DoOnEachOperatorTest.php
+++ b/test/Rx/Functional/Operator/DoOnEachOperatorTest.php
@@ -2,17 +2,15 @@
 
 namespace Rx\Functional\Operator;
 
-
 use Rx\Functional\FunctionalTestCase;
 use Rx\Observer\CallbackObserver;
 
-
-class TapTest extends FunctionalTestCase
+class DoOnEachOperatorTest extends FunctionalTestCase
 {
     /**
      * @test
      */
-    public function tap_should_see_all_values()
+    public function doOnEach_should_see_all_values()
     {
 
         $xs = $this->createHotObservable([
@@ -28,7 +26,7 @@ class TapTest extends FunctionalTestCase
         $sum = 2 + 3 + 4 + 5;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum) {
-            return $xs->tap(function ($x) use (&$i, &$sum) {
+            return $xs->doOnEach(function ($x) use (&$i, &$sum) {
                 $i++;
 
                 return $sum -= $x;
@@ -42,7 +40,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_plain_action()
+    public function doOnEach_plain_action()
     {
 
         $xs = $this->createHotObservable([
@@ -57,7 +55,7 @@ class TapTest extends FunctionalTestCase
         $i = 0;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i) {
-            return $xs->tap(function ($x) use (&$i) {
+            return $xs->doOnEach(function ($x) use (&$i) {
                 return $i++;
             });
         });
@@ -68,7 +66,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_completed()
+    public function doOnEach_next_completed()
     {
 
         $xs = $this->createHotObservable([
@@ -85,7 +83,7 @@ class TapTest extends FunctionalTestCase
         $completed = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$completed) {
-            return $xs->tap(
+            return $xs->doOnEach(
               function ($x) use (&$i, &$sum) {
                   $i++;
 
@@ -107,7 +105,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_completed_never()
+    public function doOnEach_next_completed_never()
     {
         $xs = $this->createHotObservable([
           onNext(150, 1)
@@ -117,7 +115,7 @@ class TapTest extends FunctionalTestCase
         $completed = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$completed) {
-            return $xs->tap(
+            return $xs->doOnEach(
               function ($x) use (&$i) {
                   $i++;
 
@@ -137,7 +135,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_error()
+    public function doOnEach_next_error()
     {
 
         $ex = new \Exception();
@@ -156,7 +154,7 @@ class TapTest extends FunctionalTestCase
         $sawError = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$sawError, $ex) {
-            return $xs->tap(
+            return $xs->doOnEach(
               function ($x) use (&$i, &$sum) {
                   $i++;
 
@@ -178,7 +176,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_error_not()
+    public function doOnEach_next_error_not()
     {
 
         $ex = new \Exception();
@@ -197,7 +195,7 @@ class TapTest extends FunctionalTestCase
         $sawError = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$sawError, $ex) {
-            return $xs->tap(
+            return $xs->doOnEach(
               function ($x) use (&$i, &$sum) {
                   $i++;
 
@@ -219,7 +217,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_error_completed()
+    public function doOnEach_next_error_completed()
     {
 
         $xs = $this->createHotObservable([
@@ -237,7 +235,7 @@ class TapTest extends FunctionalTestCase
         $completed = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$completed, &$sawError) {
-            return $xs->tap(
+            return $xs->doOnEach(
               function ($x) use (&$i, &$sum) {
                   $i++;
                   $sum -= $x;
@@ -261,7 +259,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_error_completed_error()
+    public function doOnEach_next_error_completed_error()
     {
         $ex = new \Exception();
 
@@ -280,7 +278,7 @@ class TapTest extends FunctionalTestCase
         $completed = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$completed, &$sawError) {
-            return $xs->tap(
+            return $xs->doOnEach(
               function ($x) use (&$i, &$sum) {
                   $i++;
                   $sum -= $x;
@@ -305,7 +303,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_error_completed_never()
+    public function doOnEach_next_error_completed_never()
     {
 
         $xs = $this->createHotObservable([
@@ -317,7 +315,7 @@ class TapTest extends FunctionalTestCase
         $completed = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$completed, &$sawError) {
-            return $xs->tap(
+            return $xs->doOnEach(
               function ($x) use (&$i, &$sum) {
                   $i++;
               },
@@ -339,7 +337,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_observer_some_data_with_error()
+    public function doOnEach_observer_some_data_with_error()
     {
         $ex = new \Exception();
 
@@ -358,7 +356,7 @@ class TapTest extends FunctionalTestCase
         $completed = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$completed, &$sawError, $ex) {
-            return $xs->tap(new CallbackObserver(
+            return $xs->doOnEach(new CallbackObserver(
               function ($x) use (&$i, &$sum) {
                   $i++;
                   $sum -= $x;
@@ -382,7 +380,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_observer_some_data_without_error()
+    public function doOnEach_observer_some_data_without_error()
     {
 
 
@@ -401,7 +399,7 @@ class TapTest extends FunctionalTestCase
         $completed = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$completed, &$sawError) {
-            return $xs->tap(new CallbackObserver(
+            return $xs->doOnEach(new CallbackObserver(
               function ($x) use (&$i, &$sum) {
                   $i++;
                   $sum -= $x;
@@ -425,7 +423,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_next_throws()
+    public function doOnEach_next_next_throws()
     {
         $ex = new \Exception();
 
@@ -436,7 +434,7 @@ class TapTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->tap(function () use ($ex) {
+            return $xs->doOnEach(function () use ($ex) {
                 throw $ex;
             });
         });
@@ -448,7 +446,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_completed_next_throws()
+    public function doOnEach_next_completed_next_throws()
     {
         $ex = new \Exception();
 
@@ -459,7 +457,7 @@ class TapTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->tap(
+            return $xs->doOnEach(
               function () use ($ex) {
                   throw $ex;
               },
@@ -475,7 +473,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_completed_completed_throws()
+    public function doOnEach_next_completed_completed_throws()
     {
         $ex = new \Exception();
 
@@ -486,7 +484,7 @@ class TapTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->tap(
+            return $xs->doOnEach(
               function () {
               },
               null,
@@ -502,7 +500,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_error_next_throws()
+    public function doOnEach_next_error_next_throws()
     {
         $ex = new \Exception();
 
@@ -513,7 +511,7 @@ class TapTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->tap(
+            return $xs->doOnEach(
               function () use ($ex) {
                   throw $ex;
               },
@@ -529,7 +527,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_error_error_throws()
+    public function doOnEach_next_error_error_throws()
     {
         $ex1 = new \Exception("error1");
         $ex2 = new \Exception("error2");
@@ -540,7 +538,7 @@ class TapTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex2) {
-            return $xs->tap(
+            return $xs->doOnEach(
               function () {
               },
               function () use ($ex2) {
@@ -557,7 +555,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_error_completed_next_throws()
+    public function doOnEach_next_error_completed_next_throws()
     {
         $ex = new \Exception();
 
@@ -568,7 +566,7 @@ class TapTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->tap(
+            return $xs->doOnEach(
               function () use ($ex) {
                   throw $ex;
               },
@@ -586,7 +584,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_error_completed_error_throws()
+    public function doOnEach_next_error_completed_error_throws()
     {
         $ex1 = new \Exception("error1");
         $ex2 = new \Exception("error2");
@@ -597,7 +595,7 @@ class TapTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex2) {
-            return $xs->tap(
+            return $xs->doOnEach(
               function () {
               },
               function () use ($ex2) {
@@ -615,7 +613,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_next_error_completed_completed_throws()
+    public function doOnEach_next_error_completed_completed_throws()
     {
         $ex = new \Exception();
 
@@ -626,7 +624,7 @@ class TapTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->tap(
+            return $xs->doOnEach(
 
               function () {
               },
@@ -645,7 +643,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_observer_next_throws()
+    public function doOnEach_observer_next_throws()
     {
         $ex = new \Exception();
 
@@ -656,7 +654,7 @@ class TapTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->tap(new CallbackObserver(
+            return $xs->doOnEach(new CallbackObserver(
 
               function () use ($ex) {
                   throw $ex;
@@ -675,7 +673,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_observer_error_throws()
+    public function doOnEach_observer_error_throws()
     {
         $ex1 = new \Exception("error1");
         $ex2 = new \Exception("error2");
@@ -686,7 +684,7 @@ class TapTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex2) {
-            return $xs->tap(new CallbackObserver(
+            return $xs->doOnEach(new CallbackObserver(
               function () {
               },
               function () use ($ex2) {
@@ -704,7 +702,7 @@ class TapTest extends FunctionalTestCase
     /**
      * @test
      */
-    public function tap_observer_completed_throws()
+    public function doOnEach_observer_completed_throws()
     {
         $ex = new \Exception();
 
@@ -715,7 +713,7 @@ class TapTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->tap(new CallbackObserver(
+            return $xs->doOnEach(new CallbackObserver(
               function () { //noop
               },
               function () { //noop

--- a/test/Rx/Functional/Operator/DoOnEachOperatorTest.php
+++ b/test/Rx/Functional/Operator/DoOnEachOperatorTest.php
@@ -26,11 +26,11 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         $sum = 2 + 3 + 4 + 5;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum) {
-            return $xs->doOnEach(function ($x) use (&$i, &$sum) {
+            return $xs->doOnEach(new CallbackObserver(function ($x) use (&$i, &$sum) {
                 $i++;
 
                 return $sum -= $x;
-            });
+            }));
         });
 
         $this->assertEquals(4, $i);
@@ -55,9 +55,9 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         $i = 0;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i) {
-            return $xs->doOnEach(function ($x) use (&$i) {
+            return $xs->doOnEach(new CallbackObserver(function ($x) use (&$i) {
                 return $i++;
-            });
+            }));
         });
 
         $this->assertEquals(4, $i);
@@ -83,7 +83,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         $completed = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$completed) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
               function ($x) use (&$i, &$sum) {
                   $i++;
 
@@ -93,7 +93,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
               function () use (&$completed) {
                   $completed = true;
               }
-            );
+            ));
         });
 
 
@@ -115,7 +115,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         $completed = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$completed) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
               function ($x) use (&$i) {
                   $i++;
 
@@ -124,7 +124,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
               function () use (&$completed) {
                   $completed = true;
               }
-            );
+            ));
         });
 
 
@@ -154,7 +154,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         $sawError = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$sawError, $ex) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
               function ($x) use (&$i, &$sum) {
                   $i++;
 
@@ -164,7 +164,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
               function ($e) use (&$sawError, $ex) {
                   $sawError = $e === $ex;
               }
-            );
+            ));
         });
 
 
@@ -195,7 +195,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         $sawError = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$sawError, $ex) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
               function ($x) use (&$i, &$sum) {
                   $i++;
 
@@ -205,7 +205,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
               function ($e) use (&$sawError, $ex) {
                   $sawError = $e === $ex;
               }
-            );
+            ));
         });
 
 
@@ -235,7 +235,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         $completed = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$completed, &$sawError) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
               function ($x) use (&$i, &$sum) {
                   $i++;
                   $sum -= $x;
@@ -246,7 +246,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
               function () use (&$completed) {
                   $completed = true;
               }
-            );
+            ));
         });
 
 
@@ -278,7 +278,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         $completed = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$completed, &$sawError) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
               function ($x) use (&$i, &$sum) {
                   $i++;
                   $sum -= $x;
@@ -289,7 +289,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
               function () use (&$completed) {
                   $completed = true;
               }
-            );
+            ));
         });
 
 
@@ -315,7 +315,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         $completed = false;
 
         $this->scheduler->startWithCreate(function () use ($xs, &$i, &$completed, &$sawError) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
               function ($x) use (&$i, &$sum) {
                   $i++;
               },
@@ -325,99 +325,13 @@ class DoOnEachOperatorTest extends FunctionalTestCase
               function () use (&$completed) {
                   $completed = true;
               }
-            );
+            ));
         });
 
 
         $this->assertEquals(0, $i);
         $this->assertFalse($sawError);
         $this->assertFalse($completed);
-    }
-
-    /**
-     * @test
-     */
-    public function doOnEach_observer_some_data_with_error()
-    {
-        $ex = new \Exception();
-
-        $xs = $this->createHotObservable([
-          onNext(150, 1),
-          onNext(210, 2),
-          onNext(220, 3),
-          onNext(230, 4),
-          onNext(240, 5),
-          onError(250, $ex)
-        ]);
-
-        $i         = 0;
-        $sum       = 2 + 3 + 4 + 5;
-        $sawError  = false;
-        $completed = false;
-
-        $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$completed, &$sawError, $ex) {
-            return $xs->doOnEach(new CallbackObserver(
-              function ($x) use (&$i, &$sum) {
-                  $i++;
-                  $sum -= $x;
-              },
-              function ($e) use (&$sawError, $ex) {
-                  $sawError = $e === $ex;
-              },
-              function () use (&$completed) {
-                  $completed = true;
-              }
-            ));
-        });
-
-
-        $this->assertEquals(4, $i);
-        $this->assertEquals(0, $sum);
-        $this->assertTrue($sawError);
-        $this->assertFalse($completed);
-    }
-
-    /**
-     * @test
-     */
-    public function doOnEach_observer_some_data_without_error()
-    {
-
-
-        $xs = $this->createHotObservable([
-          onNext(150, 1),
-          onNext(210, 2),
-          onNext(220, 3),
-          onNext(230, 4),
-          onNext(240, 5),
-          onCompleted(250)
-        ]);
-
-        $i         = 0;
-        $sum       = 2 + 3 + 4 + 5;
-        $sawError  = false;
-        $completed = false;
-
-        $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum, &$completed, &$sawError) {
-            return $xs->doOnEach(new CallbackObserver(
-              function ($x) use (&$i, &$sum) {
-                  $i++;
-                  $sum -= $x;
-              },
-              function () use (&$sawError) {
-                  $sawError = true;
-              },
-              function () use (&$completed) {
-                  $completed = true;
-              }
-            ));
-        });
-
-
-        $this->assertEquals(4, $i);
-        $this->assertEquals(0, $sum);
-        $this->assertFalse($sawError);
-        $this->assertTrue($completed);
     }
 
     /**
@@ -434,9 +348,9 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->doOnEach(function () use ($ex) {
+            return $xs->doOnEach(new CallbackObserver(function () use ($ex) {
                 throw $ex;
-            });
+            }));
         });
 
         $this->assertMessages([onError(210, $ex)], $results->getMessages());
@@ -457,13 +371,13 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
               function () use ($ex) {
                   throw $ex;
               },
               null,
               function () {
-              });
+              }));
         });
 
         $this->assertMessages([onError(210, $ex)], $results->getMessages());
@@ -484,13 +398,13 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
               function () {
               },
               null,
               function () use ($ex) {
                   throw $ex;
-              });
+              }));
         });
 
         $this->assertMessages([onNext(210, 2), onError(250, $ex)], $results->getMessages());
@@ -511,13 +425,13 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
               function () use ($ex) {
                   throw $ex;
               },
               function () {
               }
-            );
+            ));
         });
 
         $this->assertMessages([onError(210, $ex)], $results->getMessages());
@@ -538,13 +452,13 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex2) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
               function () {
               },
               function () use ($ex2) {
                   throw $ex2;
               }
-            );
+            ));
         });
 
         $this->assertMessages([onError(210, $ex2)], $results->getMessages());
@@ -566,7 +480,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
               function () use ($ex) {
                   throw $ex;
               },
@@ -574,7 +488,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
               },
               function () {
               }
-            );
+            ));
         });
 
         $this->assertMessages([onError(210, $ex)], $results->getMessages());
@@ -595,7 +509,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex2) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
               function () {
               },
               function () use ($ex2) {
@@ -603,7 +517,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
               },
               function () {
               }
-            );
+            ));
         });
 
         $this->assertMessages([onError(210, $ex2)], $results->getMessages());
@@ -624,7 +538,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
         ]);
 
         $results = $this->scheduler->startWithCreate(function () use ($xs, $ex) {
-            return $xs->doOnEach(
+            return $xs->doOnEach(new CallbackObserver(
 
               function () {
               },
@@ -633,7 +547,7 @@ class DoOnEachOperatorTest extends FunctionalTestCase
               function () use ($ex) {
                   throw $ex;
               }
-            );
+            ));
         });
 
         $this->assertMessages([onNext(210, 2), onError(250, $ex)], $results->getMessages());


### PR DESCRIPTION
- Rename `#tap()` to `#doOnEach()`
- Make `#doOnEach()` only accept an Observer as parameter