### PR TITLE
Add `#doOnNext()` operator

### DIFF
--- a/lib/Rx/Observable/BaseObservable.php
+++ b/lib/Rx/Observable/BaseObservable.php
@@ -533,6 +533,13 @@ abstract class BaseObservable implements ObservableInterface
         return $this->lift(new DoOnEachOperator($observer));
     }
 
+    public function doOnNext($onNext)
+    {
+        return $this->doOnEach(new CallbackObserver(
+            function($v) use ($onNext) { $onNext($v); }
+        ));
+    }
+
     /**
      *  Applies an accumulator function over an observable sequence and returns each intermediate result. The optional seed value is used as the initial accumulator value.
      *  For aggregation behavior with no intermediate results, see Observable.aggregate.

--- a/test/Rx/Functional/Operator/DoOnNextTest.php
+++ b/test/Rx/Functional/Operator/DoOnNextTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Rx\Functional\Operator;
+
+use Rx\Functional\FunctionalTestCase;
+use Rx\Observer\CallbackObserver;
+
+class DoOnNextOperatorTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function doOnNext_should_see_all_values()
+    {
+        $xs = $this->createHotObservable([
+          onNext(150, 1),
+          onNext(210, 2),
+          onNext(220, 3),
+          onNext(230, 4),
+          onNext(240, 5),
+          onCompleted(250)
+        ]);
+
+        $i   = 0;
+        $sum = 2 + 3 + 4 + 5;
+
+        $this->scheduler->startWithCreate(function () use ($xs, &$i, &$sum) {
+            return $xs->doOnNext(function ($x) use (&$i, &$sum) {
+                $i++;
+
+                return $sum -= $x;
+            });
+        });
+
+        $this->assertEquals(4, $i);
+        $this->assertEquals(0, $sum);
+    }
+}


### PR DESCRIPTION
The `#doOnEach()` operator accepts an observer as parameter, but
sometimes you just want to run a function for each element when
debugging. This new operation is a nice shortcut.