### PR TITLE
Add `#doOnError()` operator

### DIFF
--- a/lib/Rx/Observable/BaseObservable.php
+++ b/lib/Rx/Observable/BaseObservable.php
@@ -536,7 +536,7 @@ abstract class BaseObservable implements ObservableInterface
     public function doOnNext($onNext)
     {
         return $this->doOnEach(new CallbackObserver(
-            function($v) use ($onNext) { $onNext($v); }
+            $onNext
         ));
     }
 

--- a/lib/Rx/Observable/BaseObservable.php
+++ b/lib/Rx/Observable/BaseObservable.php
@@ -540,6 +540,14 @@ abstract class BaseObservable implements ObservableInterface
         ));
     }
 
+    public function doOnError($onError)
+    {
+        return $this->doOnEach(new CallbackObserver(
+            null,
+            $onError
+        ));
+    }
+
     /**
      *  Applies an accumulator function over an observable sequence and returns each intermediate result. The optional seed value is used as the initial accumulator value.
      *  For aggregation behavior with no intermediate results, see Observable.aggregate.

--- a/test/Rx/Functional/Operator/DoOnErrorTest.php
+++ b/test/Rx/Functional/Operator/DoOnErrorTest.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace Rx\Functional\Operator;
+
+use RuntimeException;
+use Rx\Functional\FunctionalTestCase;
+use Rx\Observer\CallbackObserver;
+
+class DoOnErrorTest extends FunctionalTestCase
+{
+    /**
+     * @test
+     */
+    public function doOnError_should_see_errors()
+    {
+        $ex = new RuntimeException('boom!');
+        $xs = $this->createHotObservable([
+          onNext(150, 1),
+          onNext(210, 2),
+          onError(220, $ex),
+          onCompleted(250)
+        ]);
+
+        $called = 0;
+        $error = null;
+
+        $this->scheduler->startWithCreate(function () use ($xs, &$called, &$error) {
+            return $xs->doOnError(function ($err) use (&$called, &$error) {
+                $called++;
+                $error = $err;
+            });
+        });
+
+        $this->assertEquals(1, $called);
+        $this->assertSame($ex, $error);
+    }
+}

--- a/test/Rx/Functional/Operator/DoOnNextTest.php
+++ b/test/Rx/Functional/Operator/DoOnNextTest.php
@@ -5,7 +5,7 @@ namespace Rx\Functional\Operator;
 use Rx\Functional\FunctionalTestCase;
 use Rx\Observer\CallbackObserver;
 
-class DoOnNextOperatorTest extends FunctionalTestCase
+class DoOnNextTest extends FunctionalTestCase
 {
     /**
      * @test


### PR DESCRIPTION
The `#doOnEach()` operator accepts an observer as parameter, but
sometimes you just want to run a function when things error. This new
operation is a nice shortcut.